### PR TITLE
some small fixes - linux build, readme, file conversion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,13 +31,13 @@ With these printers I can only convert from gcode to 3w files and back.  They us
    da Vinci 1.0  
    da Vinci 1.0A  
    da Vinci 1.0 AiO  
-   da Vinci 1.1 Plus *** May partially work over usb
+   da Vinci 1.1 Plus *** May partially work over usb ***  
    da Vinci 2.0 Duo  
    da Vinci 2.0A Duo  
 
 This comes in two flavors, a win32 GUI and a command line utility.
 
-![My image](http://soliforum.com/i/?lCv3Sh3.png)
+![My image](https://i.imgur.com/lCv3Sh3.png)
 
 Here is a summary of the commands that the command line can take.
 
@@ -78,7 +78,7 @@ It also uses a stripped down version of miniz by richgel999
 
 https://github.com/richgel999/miniz
 
-For downloading firmware from the website this also uses Internet.hpp from Elmü's code project
+For downloading firmware from the website this also uses Internet.hpp from ElmÃ¼'s code project
 
 https://www.codeproject.com/Articles/15397/Cabinet-File-CAB-Compression-and-Extraction
 

--- a/miniMoverConsole/Makefile
+++ b/miniMoverConsole/Makefile
@@ -2,7 +2,7 @@ PROG = minimover
 CC = g++
 CPPFLAGS = -g -Wall -I../miniMoverLib/ -D _DEBUG
 LDFLAGS = 
-OBJS = minimover.o xyzv3.o xyzprinterlist.o serial_linux.o stream.o miniz.o debug.o aes.o timer.o socket_linux.o 
+OBJS = minimover.o xyzv3.o XYZPrinterList.o serial_linux.o stream.o miniz.o debug.o aes.o timer.o socket_linux.o 
 
 $(PROG) : $(OBJS)
 	$(CC) $(LDFLAGS) -o $(PROG) $(OBJS)
@@ -13,8 +13,8 @@ minimover.o: minimover.cpp
 xyzv3.o: ../miniMoverLib/xyzv3.cpp ../miniMoverLib/xyzv3.h
 	$(CC) $(CPPFLAGS) -c ../miniMoverLib/xyzv3.cpp
 
-xyzprinterlist.o: ../miniMoverLib/xyzprinterlist.cpp ../miniMoverLib/xyzprinterlist.h
-	$(CC) $(CPPFLAGS) -c ../miniMoverLib/xyzprinterlist.cpp
+XYZPrinterList.o: ../miniMoverLib/XYZPrinterList.cpp ../miniMoverLib/XYZPrinterList.h
+	$(CC) $(CPPFLAGS) -c ../miniMoverLib/XYZPrinterList.cpp
 
 serial_linux.o: ../miniMoverLib/serial_linux.cpp ../miniMoverLib/serial.h
 	$(CC) $(CPPFLAGS) -c ../miniMoverLib/serial_linux.cpp

--- a/miniMoverConsole/minimover.cpp
+++ b/miniMoverConsole/minimover.cpp
@@ -710,7 +710,6 @@ int main(int argc, char **argv)
 						if(i+1 < argc && !isKey(argv[i+1])) 
 						{
 							printf("starting convert file\n");
-							checkCon(); 
 							xyz.convertFileStart(argv[i+1]);
 							while(xyz.isInProgress())
 								doProcessWithSleep(); //****FixMe, print progress

--- a/miniMoverLib/xyzv3.cpp
+++ b/miniMoverLib/xyzv3.cpp
@@ -1426,7 +1426,8 @@ void XYZV3::doProcess()
 {
 	debugPrint(DBG_LOG, "XYZV3::doProcess() %d", m_actState);
 
-	if(!m_stream 
+	if(m_actState != ACT_CF_START && m_actState != ACT_CF_COMPLETE
+		&& !m_stream
 //		|| !m_stream->isOpen()
 		)
 		setState(ACT_FAILURE);


### PR DESCRIPTION
Fixes:
- Linux build was not working since the case of xyzprinterlist was incorrect.
- Removes connection checks when only doing 3w <-> gcode conversion, now conversion also works without connection.
- readme.md fix image url and newline

PS. I hope you don't mind these unrelated changes in one pull request.